### PR TITLE
Fixed Issue related to admin_id in createSubadmin()

### DIFF
--- a/Backend/src/main/java/com/Backend/Controller/SubadminController.java
+++ b/Backend/src/main/java/com/Backend/Controller/SubadminController.java
@@ -41,9 +41,13 @@ public class SubadminController {
 
     // Create a new Subadmin
     @PostMapping
-    public ResponseEntity<Subadmin> createSubadmin(@RequestBody Subadmin subadmin) {
+    public ResponseEntity<Subadmin> createSubadmin(
+            @RequestParam Long admin_id,
+            @RequestBody Subadmin subadmin) {
+
         try {
-            Subadmin createdSubadmin = subadminService.createSubadmin(subadmin);
+            // Create Subadmin with the given adminId
+            Subadmin createdSubadmin = subadminService.createSubadmin(subadmin, admin_id);
             return ResponseEntity.ok(createdSubadmin);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/Backend/src/main/java/com/Backend/Entities/Subadmin.java
+++ b/Backend/src/main/java/com/Backend/Entities/Subadmin.java
@@ -31,7 +31,7 @@ public class Subadmin {
     private String station;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "admin_id")
+    @JoinColumn(name = "admin_id", nullable = false)
     @JsonIgnore
     private Admin admin;
 

--- a/Backend/src/main/java/com/Backend/Service/SubadminService.java
+++ b/Backend/src/main/java/com/Backend/Service/SubadminService.java
@@ -4,21 +4,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.Backend.Entities.Admin;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 import com.Backend.Entities.Subadmin;
 import com.Backend.Repository.SubadminRepository;
+import com.Backend.Repository.AdminRepository;
 
 @Service
 public class SubadminService {
 
     private final SubadminRepository subadminRepository;
+    private final AdminRepository adminRepository;
 
     @Autowired
-    public SubadminService(SubadminRepository subadminRepository){
+    public SubadminService(SubadminRepository subadminRepository, AdminRepository adminRepository){
         this.subadminRepository = subadminRepository;
+        this.adminRepository = adminRepository;
     }
 
     public List<Subadmin> getAllSubadmins(){
@@ -38,15 +42,18 @@ public class SubadminService {
         }
         return null;
     }
-
-    public Subadmin createSubadmin(Subadmin subadmin) {
+    public Subadmin createSubadmin(Subadmin subadmin, Long adminId) {
         try {
+            Admin admin = adminRepository.findById(adminId)
+                    .orElseThrow(() -> new IllegalArgumentException("Admin not found with id: " + adminId));
+            subadmin.setAdmin(admin);
             return subadminRepository.save(subadmin);
         } catch (DataAccessException e) {
-            e.printStackTrace();
-        }
+            e.printStackTrace();}
         return null;
     }
+
+
 
     public Subadmin updateSubadmin(Long id, Subadmin updatedSubadmin) {
         try {


### PR DESCRIPTION
In a JPA entity, the relationship mapping cannot be directly represented as a String for foreign key fields. So took admin_id as requestParam and then created obj of admin class through id which is then set to admin_id in subdmin entity